### PR TITLE
Changed `ARCHS` build setting to `ARCHS_STANDARD`

### DIFF
--- a/Finch.xcodeproj/project.pbxproj
+++ b/Finch.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEFINES_MODULE = YES;
 				DSTROOT = /tmp/Finch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Finch/Lib-Prefix.pch";
@@ -698,6 +699,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEFINES_MODULE = YES;
 				DSTROOT = /tmp/Finch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Finch/Lib-Prefix.pch";

--- a/Finch.xcodeproj/project.pbxproj
+++ b/Finch.xcodeproj/project.pbxproj
@@ -643,7 +643,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -666,7 +666,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;


### PR DESCRIPTION
* Changed the `ARCHS` build setting for the “Finch” (static lib) target from `ARCHS_STANDARD_32_BIT` to `ARCHS_STANDARD` so that it can be built for 64-bit devices.  
	‣ 32-bit iOS devices are pretty ancient now, though some are still supported (A5 & A6 devices).  `ARCHS_STANDARD` includes `armv7` for those devices (in the latest Xcode, v8.0) as well as `arm64` for all 64-bit iOS devices.