### PR TITLE
Set “Defines Module” build setting to Yes for “Finch”

### DIFF
--- a/Finch.xcodeproj/project.pbxproj
+++ b/Finch.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEFINES_MODULE = YES;
 				DSTROOT = /tmp/Finch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Finch/Lib-Prefix.pch";
@@ -698,6 +699,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEFINES_MODULE = YES;
 				DSTROOT = /tmp/Finch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Finch/Lib-Prefix.pch";


### PR DESCRIPTION
* Set the `DEFINES_MODULE` build setting for the “Finch” (static lib) target to `YES` for better interop with Swift— all of Finch's classes will be accessible under the `Finch.…` “namespace”, or via files with `import Finch`.