### PR TITLE
Fixed “error: bad receiver type 'CMSampleBufferRef _Nullable’”

### DIFF
--- a/Finch/FISound.m
+++ b/Finch/FISound.m
@@ -4,7 +4,7 @@
 #import "FISoundSource.h"
 
 @interface FISound ()
-@property(strong) NSArray *voices;
+@property(strong) NSArray<FISoundSource*> *voices;
 @property(assign) NSUInteger currentVoiceIndex;
 @end
 

--- a/Finch/FISound.m
+++ b/Finch/FISound.m
@@ -59,7 +59,7 @@
 
 - (NSTimeInterval) duration
 {
-    return [[(FISoundSource*)[_voices lastObject] sampleBuffer] duration];
+    return [[[_voices lastObject] sampleBuffer] duration];
 }
 
 - (void) forwardInvocation: (NSInvocation*) invocation


### PR DESCRIPTION
Fixed `error: bad receiver type 'CMSampleBufferRef _Nullable' (aka 'struct opaqueCMSampleBuffer *')` when trying to do `[[[_voices lastObject] sampleBuffer] duration]` (where `_voices` is an array of `FISoundSource`s) in the current version of Xcode (9.3).  The issue seems to be that the compiler is strangely assuming `[[_voices lastObject] sampleBuffer]` to return a `CMSampleBufferRef` rather than a `FISampleBuffer *`.

Fixed by adopting the lightweight generics syntax added in Xcode 7 and typing `_voices` as `NSArray<FISoundSource*> *` (instead of just `NSArray *`).  This seems to be enough to tell the compiler that `[_voices lastObject]` is a `FISoundSource *` and therefore calling `sampleBuffer` on it will give us the expected `FISampleBuffer *`.

Alternatively, we could just do a cast like `(FISampleBuffer *)[[_voices lastObject] sampleBuffer]` here to retain full code compatibility with older Xcode versions.  I don't recall what happens if older Xcodes encounter the lightweight generics syntax.